### PR TITLE
Allow sane Alert class updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.floo*
+.idea/

--- a/alertmanager.py
+++ b/alertmanager.py
@@ -138,6 +138,9 @@ class Alert(collections.UserDict):
 
     @data.setter
     def data(self, dict_data):
+        if not dict_data:
+            return
+
         __local_data_dict = copy.deepcopy(self.__data_dict)
         __local_data_dict.update(dict_data)
         if not self._validate(__local_data_dict):
@@ -178,7 +181,7 @@ class Alert(collections.UserDict):
         # Userdict don't expect the dict to be managed by attributes, that
         # is why we must implement this. Offer presynced because sometimes
         # we may wanna bypass the extra OP
-        if self.data.get(key) and not presynced:
+        if not key.startswith('_') and key != 'data' and not presynced:
             self.data[key] = value
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
* Refactors _raw to data ( This is a requirement for UserDict)

UserDict allows us the benefit of having the Alert class act MOSTLY like a dict right out of the gate. Personally this is my preference, because Alert won't do much but just be a collection of data

This also allows users to post Raw Dictionaries to AlertManager if they want, so we don't have a firm dependency on JUST Alerts **UNTESTED**


`__setattr__`
`__setitem__`

These over overrides, so we can allow someone to do the following properly. Without them, only  
   ` test['endsAt'] = "__setitem__"` would work properly

`    starts_at = datetime.datetime.utcnow()
    ends_at = starts_at + datetime.timedelta(minutes=2)
    starts_at = starts_at.isoformat("T") + "Z"
    ends_at = ends_at.isoformat("T") + "Z"

    test_data = {
        "labels": {
            "alertname": "Testeroni",
            "dev": "test",
            "instance": "no_instance",
            "severity": "warning"
        },
        "annotations": {
            "description": "This is only a test.",
            "info": "Simple test",
            "summary": "Please ignore"
        },
        "startsAt": starts_at,
        "endsAt": ends_at,
        "generatorURL": "",
        "status": {
            "state": "unprocessed",
            "silencedBy": [],
            "inhibitedBy": []
        },
        "receivers": [
            "slack-bottesting"
        ]
    }

    s = requests.Session()
    a_manager = AlertManager('http://127.0.0.1', req_obj=s)
    test = Alert.from_dict(test_data)

    print(test)
    print("{} #2018-04-22T17:20:46.379275Z".format(test.endsAt))
    print("{} #2018-04-22T17:20:46.379275Z".format(test['endsAt']))

    test.endsAt = "SetAttr"
    print("{} #SetAttr".format(test.endsAt))
    print("{} #SetAttr".format(test['endsAt']))
    print(test)
    print(test.data)

    test['endsAt'] = "__setitem__"
    print("{} #__setitem__".format(test.endsAt))
    print("{} #__setitem__".format(test['endsAt']))

    print(test)
    print(test.data)

    test.data = {'endsAt': '2019-04-22T17:20:46.379275Z'}

    print("{} #2019-04-22T17:20:46.379275Z".format(test.endsAt))
    print("{} #2019-04-22T17:20:46.379275Z".format(test['endsAt']))

    print(test)
    print(test.data)`