### PR TITLE
Filter support

### DIFF
--- a/alertmanager/alertmanager.py
+++ b/alertmanager/alertmanager.py
@@ -71,12 +71,18 @@ class AlertManager(object):
 
     def get_alerts(self, **kwargs):
         route = "/api/v1/alerts"
-        print(kwargs)
+        self._validate_get_alert_kwargs(**kwargs)
         if kwargs['filter']:
             kwargs['filter'] = self._handle_filters(kwargs['filter'])
         r = self._make_request("GET", route, **kwargs)
         if self._check_response(r):
             return Alert.from_dict(r.json())
+
+    def _validate_get_alert_kwargs(self, **kwargs):
+        valid_keys = ['filter', 'silenced', 'inhibited']
+        for key in kwargs.keys():
+            if key not in valid_keys:
+                raise KeyError('invalid get parameter {}'.format(key))
 
     def _handle_filters(self, filter_dict):
         if not isinstance(filter_dict, dict):

--- a/alertmanager/alertmanager.py
+++ b/alertmanager/alertmanager.py
@@ -51,15 +51,15 @@ class AlertManager(object):
         _host = "{}:{}".format(self.hostname, self.port)
         route = urljoin(_host, route)
 
-        r = self.request_session.request(method, route, kwargs)
+        r = self.request_session.request(method, route, **kwargs)
         return r
 
     def get_alerts(self, **kwargs):
         route = "/api/v1/alerts"
         self._validate_get_alert_kwargs(**kwargs)
-        if kwargs['filter']:
+        if kwargs.get('filter'):
             kwargs['filter'] = self._handle_filters(kwargs['filter'])
-        r = self._make_request("GET", route, **kwargs)
+        r = self._make_request("GET", route, params=kwargs)
         if self._check_response(r):
             return Alert.from_dict(r.json())
 

--- a/alertmanager/alertmanager.py
+++ b/alertmanager/alertmanager.py
@@ -6,22 +6,7 @@ import logging
 import json
 import copy
 import maya
-import logging
 from box import Box, BoxKeyError
-
-try:
-    import http.client as http_client
-except ImportError:
-    # Python 2
-    import httplib as http_client
-http_client.HTTPConnection.debuglevel = 1
-
-# You must initialize logging, otherwise you'll not see debug output.
-logging.basicConfig()
-logging.getLogger().setLevel(logging.DEBUG)
-requests_log = logging.getLogger("requests.packages.urllib3")
-requests_log.setLevel(logging.DEBUG)
-requests_log.propagate = True
 
 
 class AlertManager(object):


### PR DESCRIPTION
Added support for filters/inhibitions/silences on the `get_alerts()` method. The method now accepts kwargs. We validate keys based on values we know are get parameters for the alertmanager api to ensure correct usage. 

Filters should be submitted as dicts, where the key is the matcher and the value is the value on by which we determine a match. `_handle_filters()` ensures that if the `filter` key is present in the kwargs passed to get_alerts() is a dict. After validated, it converts the dict into a valid matcher string.